### PR TITLE
feat(task): add clear_logs task

### DIFF
--- a/backend/tauri/src/config/verge.rs
+++ b/backend/tauri/src/config/verge.rs
@@ -86,6 +86,10 @@ pub struct IVerge {
     /// proxy 页面布局 列数
     pub proxy_layout_column: Option<i32>,
 
+    /// 日志清理
+    /// 分钟数； 0 为不清理
+    pub auto_log_clean: Option<i64>,
+
     /// window size and position
     #[serde(skip_serializing_if = "Option::is_none")]
     pub window_size_position: Option<Vec<f64>>,
@@ -151,6 +155,7 @@ impl IVerge {
             enable_builtin_enhanced: Some(true),
             enable_clash_fields: Some(true),
             page_transition_animation: Some("slide".into()),
+            auto_log_clean: Some(60 * 24 * 7), // 7 days 自动清理日记
             ..Self::default()
         }
     }
@@ -201,6 +206,7 @@ impl IVerge {
         patch!(proxy_layout_column);
         patch!(enable_clash_fields);
 
+        patch!(auto_log_clean);
         patch!(window_size_position);
     }
 

--- a/backend/tauri/src/main.rs
+++ b/backend/tauri/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod core;
 mod enhance;
 mod feat;
+mod tasks;
 mod utils;
 
 use crate::utils::{init, resolve, server};

--- a/backend/tauri/src/tasks/logger.rs
+++ b/backend/tauri/src/tasks/logger.rs
@@ -1,0 +1,72 @@
+use crate::config::Config;
+use crate::utils::dirs;
+use anyhow::Result;
+use chrono::{DateTime, Local, TimeZone};
+use std::fs::{self, DirEntry};
+use std::str::FromStr;
+
+/// Clear logs from the logs directory
+pub fn clear_logs() -> Result<()> {
+    let log_dir = dirs::app_logs_dir()?;
+    if !log_dir.exists() {
+        return Ok(());
+    }
+
+    let minutes = {
+        let verge = Config::verge();
+        let verge = verge.data();
+        verge.auto_log_clean.unwrap_or(0)
+    };
+    if minutes == 0 {
+        return Ok(()); // 0 means disable
+    }
+    log::debug!(target: "app", "try to delete log files, minutes: {minutes}");
+
+    // %Y-%m-%d to NaiveDateTime
+    let parse_time_str = |s: &str| {
+        let sa: Vec<&str> = s.split('-').collect();
+        if sa.len() != 4 {
+            return Err(anyhow::anyhow!("invalid time str"));
+        }
+
+        let year = i32::from_str(sa[0])?;
+        let month = u32::from_str(sa[1])?;
+        let day = u32::from_str(sa[2])?;
+        let time = chrono::NaiveDate::from_ymd_opt(year, month, day)
+            .ok_or(anyhow::anyhow!("invalid time str"))?
+            .and_hms_opt(0, 0, 0)
+            .ok_or(anyhow::anyhow!("invalid time str"))?;
+        Ok(time)
+    };
+
+    let process_file = |file: DirEntry| -> Result<()> {
+        let file_name = file.file_name();
+        let file_name = file_name.to_str().unwrap_or_default();
+
+        if file_name.ends_with(".log") {
+            let now = Local::now();
+            let created_time = parse_time_str(&file_name[0..file_name.len() - 4])?;
+            let created_time: DateTime<Local> = Local.from_local_datetime(&created_time).unwrap(); // It is safe to use `unwrap` here because we just parsed it
+
+            let duration = now.signed_duration_since(created_time);
+            if duration.num_minutes() > minutes {
+                let file_path = file.path();
+                let _ = fs::remove_file(file_path);
+                log::info!(target: "app", "delete log file: {file_name}");
+            }
+        }
+        Ok(())
+    };
+
+    for file in fs::read_dir(&log_dir)? {
+        match file {
+            Ok(file) => {
+                let _ = process_file(file);
+            }
+            Err(err) => {
+                log::error!(target: "app", "read log dir error: {err}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/backend/tauri/src/tasks/mod.rs
+++ b/backend/tauri/src/tasks/mod.rs
@@ -1,0 +1,4 @@
+/// 本模块存放一次性执行的 Job 以及定时任务
+pub mod logger;
+
+pub fn register_cronjob() {}


### PR DESCRIPTION
Close https://github.com/keiko233/clash-nyanpasu/issues/43
移植并改进 https://github.com/zzzgydi/clash-verge/commit/e0d26203dd42cfa7ed3ecadcad24b90b4f5d78d1

* [x] 重新实现基于分钟的清理任务
* [ ] 重新实现 timer，消除和 profiles 深度耦合的设计，并将清理日记的 task 间隔设置为三十分钟。
* [ ] 实现前端设置页面