### PR TITLE
fix: dev build

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -2,10 +2,11 @@ name: Dev Build
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - dev
-
+  # push:
+  #   branches:
+  #     - dev
+  schedule:
+    - cron: "15 0 * * *" # 每天 08:15 UTC+8 自动构建
 env:
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: short
@@ -21,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: dev # Dev branch
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -52,7 +55,7 @@ jobs:
         uses: mknejp/delete-release-assets@v1
         with:
           token: ${{ secrets.GH_TOKEN }}
-          tag: dev
+          tag: pre-release
           fail-if-no-assets: false
           fail-if-no-release: false
           assets: |
@@ -84,7 +87,7 @@ jobs:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
-          tagName: dev
+          tagName: pre-release
           releaseName: "Clash Nyanpasu Dev"
           releaseBody: "More new features are now supported."
           releaseDraft: false
@@ -97,7 +100,7 @@ jobs:
         run: |
           pnpm portable
         env:
-          TAG_NAME: dev
+          TAG_NAME: pre-release
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
@@ -111,7 +114,7 @@ jobs:
       - name: Tauri build with Upload (macOS aarch64)
         if: startsWith(matrix.os, 'macos-')
         env:
-          TAG_NAME: dev
+          TAG_NAME: pre-release
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}


### PR DESCRIPTION
* 将 Dev 发布使用的 tag 修改为 `pre-release`
* 由 push 触发，修改成每日构建；配合手动触发，应该足够使用。
  * 考虑到前端的库更新非常频繁，每日可能会有多个依赖更新被自动合并进去，非常浪费 CI 资源以及时间资源。
  * 或许可以加一个 build 测试？

有必要给 dev 单独做一个 updater json，方便使用这个 channel 的也能享受每日的自动更新？ 
以及，文档是准备本仓库的 docs 存放，还是另开个仓库？