### PR TITLE
fix(rocksdb): resource busy issue

### DIFF
--- a/backend/tauri/src/core/storage.rs
+++ b/backend/tauri/src/core/storage.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock};
 /// storage is a wrapper or called a facade for the rocksdb
 /// Maybe provide a facade for a kv storage is a good idea?
 pub struct Storage {
-    instance: rocksdb::OptimisticTransactionDB<MultiThreaded>,
+    instance: rocksdb::TransactionDB<MultiThreaded>,
     path: String,
 }
 
@@ -15,13 +15,12 @@ impl Storage {
 
         STORAGE.get_or_init(|| {
             let path = dirs::storage_path().unwrap().to_str().unwrap().to_string();
-            let instance =
-                rocksdb::OptimisticTransactionDB::<MultiThreaded>::open_default(&path).unwrap();
+            let instance = rocksdb::TransactionDB::<MultiThreaded>::open_default(&path).unwrap();
             Arc::new(Storage { instance, path })
         })
     }
 
-    pub fn get_instance(&self) -> &rocksdb::OptimisticTransactionDB<MultiThreaded> {
+    pub fn get_instance(&self) -> &rocksdb::TransactionDB<MultiThreaded> {
         &self.instance
     }
 


### PR DESCRIPTION
related: https://github.com/hyperledger/besu/issues/4639 https://github.com/hyperledger/besu/issues/3719 https://github.com/hyperledger/besu/pull/3720

fix: https://github.com/keiko233/clash-nyanpasu/issues/190

手动对乐观事务 Busy 的情况进行重试似乎不太经济。因此直接使用普通事务模式。