### PR TITLE
fix(macos): enable_tun block the process

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.74.1"


### PR DESCRIPTION
Start this App with `enable_tun` will be no response

Related issue: https://github.com/tauri-apps/tauri/pull/8539

Only do `recv` once manually without waiting for more