### PR TITLE
fix: sort connection in numerical comparison for Download, DL Speed, etc

### DIFF
--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -24,6 +24,7 @@ export const ConnectionTable = (props: Props) => {
       width: 88,
       align: "right",
       headerAlign: "right",
+      valueFormatter: ({ value }) => parseTraffic(value).join(" "),
     },
     {
       field: "upload",
@@ -31,6 +32,7 @@ export const ConnectionTable = (props: Props) => {
       width: 88,
       align: "right",
       headerAlign: "right",
+      valueFormatter: ({ value }) => parseTraffic(value).join(" "),
     },
     {
       field: "dlSpeed",
@@ -38,6 +40,7 @@ export const ConnectionTable = (props: Props) => {
       width: 88,
       align: "right",
       headerAlign: "right",
+      valueFormatter: ({ value }) => parseTraffic(value).join(" ") + "/s",
     },
     {
       field: "ulSpeed",
@@ -45,6 +48,7 @@ export const ConnectionTable = (props: Props) => {
       width: 88,
       align: "right",
       headerAlign: "right",
+      valueFormatter: ({ value }) => parseTraffic(value).join(" ") + "/s",
     },
     { field: "chains", headerName: "Chains", flex: 360, minWidth: 360 },
     { field: "rule", headerName: "Rule", flex: 300, minWidth: 250 },
@@ -78,10 +82,10 @@ export const ConnectionTable = (props: Props) => {
         host: metadata.host
           ? `${metadata.host}:${metadata.destinationPort}`
           : `${metadata.destinationIP}:${metadata.destinationPort}`,
-        download: parseTraffic(each.download).join(" "),
-        upload: parseTraffic(each.upload).join(" "),
-        dlSpeed: parseTraffic(each.curDownload).join(" ") + "/s",
-        ulSpeed: parseTraffic(each.curUpload).join(" ") + "/s",
+        download: each.download,
+        upload: each.upload,
+        dlSpeed: each.curDownload,
+        ulSpeed: each.curUpload,
         chains,
         rule,
         process: truncateStr(metadata.process || metadata.processPath),


### PR DESCRIPTION
Use valueFormatter to only change the way data is displayed, without altering the data itself, so that columns can be sorted by numerical comparison.

For example, `200` and `1000` would be displayed as the strings `200 B` and `1 KB`, but still compared numerically as `200 < 1000`, rather than by the dictionary order of the strings.

close #336